### PR TITLE
Launch Playwright-driven authorization browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# anyrouter_auto
+# AnyRouter Auto
+
+> Minimal-dependency CLI helper to automate the daily sign-in on [anyrouter.top](https://anyrouter.top/).
+
+## Features
+
+- Generates OAuth authorization URL for the GitHub login flow and captures the callback via a lightweight local HTTP server.
+- Opens the authorization link with the default system browser (or lets you copy it manually) for GitHub sign-in.
+- Stores access and refresh tokens using a JSON file with optional passphrase-based obfuscation.
+- Provides `authorize`, `signin`, `status`, `schedule`, and `clear` commands via a single CLI entry point.
+- Persists sign-in history in CSV format for later inspection.
+- Ships a simple daily scheduler implemented with the Python standard library only.
+
+## Installation
+
+The project targets Python 3.11+. Create a virtual environment and install the package locally:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .
+```
+
+## Configuration
+
+Create a GitHub OAuth application for `https://anyrouter.top/` (or request the client identifier from the service owner). Supply this identifier in one of the following ways:
+
+- Export the `ANYROUTER_CLIENT_ID` environment variable before running the CLI; **or**
+- Pass `--client-id <value>` to the `authorize` command; **or**
+- Simply run `anyrouter-auto authorize` and enter the value interactively when prompted.
+
+The CLI stores the provided client identifier alongside the OAuth tokens, so subsequent `signin`/`schedule` runs do not require the environment variable. Adjust the daily schedule via the `ANYROUTER_SCHEDULE_HOUR` and `ANYROUTER_SCHEDULE_MINUTE` variables if needed.
+
+Invoke the CLI with either the hyphenated `anyrouter-auto` script name or the underscore variant `anyrouter_auto`—both entry points are installed for convenience.
+
+## Usage
+
+1. **Authorize**
+   ```bash
+   anyrouter-auto authorize --client-id <github_client_id>
+   ```
+   Omit `--client-id` if you exported `ANYROUTER_CLIENT_ID` or prefer to type the identifier when prompted. The command prints the authorization URL and attempts to launch it with your system browser so you can finish the GitHub login flow. After granting access, the CLI exchanges the authorization code and stores the resulting tokens (including the client identifier) in `~/.anyrouter_auto/credentials.json`. If the browser cannot be opened automatically, copy the printed URL manually.
+
+2. **Manual sign-in**
+   ```bash
+   anyrouter-auto signin  # or: anyrouter_auto signin
+   ```
+   The CLI refreshes expired access tokens automatically (if a refresh token is available), performs the sign-in request, and logs the result to `history.csv`.
+
+3. **Status overview**
+   ```bash
+   anyrouter-auto status
+   ```
+   Displays information about the stored credentials and prints the latest history entries.
+
+4. **Daily scheduler**
+   ```bash
+   anyrouter-auto schedule
+   ```
+   Starts a background loop that executes the sign-in once per day. Stop the process with `Ctrl+C`.
+
+5. **Clear credentials**
+   ```bash
+   anyrouter-auto clear
+   ```
+   Removes the stored credential file.
+
+Pass `--passphrase` to `authorize`, `signin`, `status`, or `schedule` to protect the credential file with a user-provided secret.
+
+## Development
+
+- Code style follows standard library modules and keeps runtime dependencies minimal.
+- Tests are not provided in this initial drop. You can verify import-time regressions with `python -m compileall anyrouter_auto`.
+
+## Disclaimer
+
+The HTTP endpoints used here are based on assumptions of the anyrouter.top API surface and may require adjustments to match the real service responses. Review and adapt the network calls (`anyrouter_auto/auth.py` and `anyrouter_auto/signin.py`) before using the tool in production.

--- a/anyrouter_auto/__init__.py
+++ b/anyrouter_auto/__init__.py
@@ -1,0 +1,32 @@
+"""Automation toolkit for AnyRouter daily sign-in."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+__all__ = ["__version__", "read_text_resource"]
+
+
+def __version__() -> str:
+    """Return package version.
+
+    The version is stored in :mod:`anyrouter_auto.version` to keep the import
+    graph lightweight for CLI usage. A fallback of ``"0.1.0"`` is returned when
+    the version module is missing (for example during local development).
+    """
+
+    try:
+        from .version import VERSION
+    except Exception:  # pragma: no cover - defensive fallback
+        return "0.1.0"
+    return VERSION
+
+
+def read_text_resource(package: str, name: str) -> str:
+    """Read an embedded text resource from *package*.
+
+    This helper is used by the CLI to ship default templates without touching
+    the filesystem when running from a frozen binary.
+    """
+
+    return resources.files(package).joinpath(name).read_text(encoding="utf-8")

--- a/anyrouter_auto/__main__.py
+++ b/anyrouter_auto/__main__.py
@@ -1,0 +1,201 @@
+"""Command line interface for AnyRouter automation."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+import webbrowser
+from .auth import AuthorizationFlow
+from .config import OAuthConfig, get_client_id
+from .credentials import CredentialRecord, CredentialStore
+from .history import HistoryStore
+from .scheduler import DailyScheduler
+from .signin import SignInClient
+
+LOGGER = logging.getLogger("anyrouter_auto")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Automate AnyRouter daily sign-in")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    authorize = sub.add_parser("authorize", help="Start OAuth authorization")
+    authorize.add_argument("--client-id", help="GitHub OAuth client id", default=None)
+    authorize.add_argument("--passphrase", help="Optional passphrase for credential storage")
+
+    signin = sub.add_parser("signin", help="Execute the sign-in flow once")
+    signin.add_argument("--passphrase", help="Passphrase used during authorization")
+
+    status = sub.add_parser("status", help="Show credential & history state")
+    status.add_argument("--passphrase", help="Passphrase used during authorization")
+    status.add_argument("--limit", type=int, default=10, help="Number of history entries to show")
+
+    schedule = sub.add_parser("schedule", help="Start background scheduler")
+    schedule.add_argument("--passphrase", help="Passphrase used during authorization")
+
+    clear = sub.add_parser("clear", help="Remove stored credentials")
+
+    parser.add_argument("--log-level", default="INFO", help="Logging level (default: INFO)")
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO), format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def _load_store(passphrase: str | None) -> CredentialStore:
+    return CredentialStore(passphrase=passphrase)
+
+
+def cmd_authorize(args: argparse.Namespace) -> None:
+    client_id = args.client_id or get_client_id()
+    if not client_id:
+        try:
+            client_id = input("Enter your GitHub OAuth client id: ").strip()
+        except EOFError:
+            client_id = ""
+        if not client_id:
+            print(
+                "GitHub client id required. Re-run with --client-id or set ANYROUTER_CLIENT_ID.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    store = _load_store(args.passphrase)
+    config = OAuthConfig(client_id=client_id)
+    flow = AuthorizationFlow(config, store)
+    state = flow.generate_state()
+    url = flow.build_authorization_url(state)
+    print("Open the following URL in your browser to authorize:")
+    print(url)
+    if not webbrowser.open(url):
+        LOGGER.info("Unable to launch a browser automatically. Please copy the URL manually.")
+    print("Waiting for callback...")
+    try:
+        result = flow.wait_for_callback(state)
+    except TimeoutError as exc:
+        print(f"Authorization timed out: {exc}", file=sys.stderr)
+        sys.exit(2)
+    record = flow.exchange_code(result)
+    print("Authorization succeeded. Access token stored.")
+    if record.expires_at:
+        print(f"Token expires at {record.expires_at}")
+
+
+def _ensure_credentials(
+    store: CredentialStore, flow: AuthorizationFlow, record: CredentialRecord | None = None
+) -> CredentialRecord:
+    if record is None:
+        record = store.load()
+    if record is None:
+        raise RuntimeError("Credentials missing. Run authorize first.")
+    if record.is_expired:
+        LOGGER.info("Access token expired. Refreshing...")
+        record = flow.refresh(record)
+    return record
+
+
+def cmd_signin(args: argparse.Namespace) -> None:
+    store = _load_store(args.passphrase)
+    try:
+        record = store.load()
+    except Exception as exc:
+        print(f"Unable to load credentials: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if record is None:
+        print("Credentials missing. Run authorize first.", file=sys.stderr)
+        sys.exit(1)
+    client_id = get_client_id() or record.client_id
+    if not client_id:
+        print(
+            "GitHub client id unavailable. Set ANYROUTER_CLIENT_ID or re-run authorize with --client-id.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    flow = AuthorizationFlow(OAuthConfig(client_id=client_id), store)
+    record = _ensure_credentials(store, flow, record)
+    client = SignInClient()
+    result = client.perform_sign_in(record)
+    HistoryStore().append(result)
+    print(SignInClient.format_result(result))
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    store = _load_store(args.passphrase)
+    record = store.load()
+    if not record:
+        print("No credentials stored.")
+    else:
+        status = "expired" if record.is_expired else "valid"
+        print(f"Access token: {record.access_token[:6]}... status={status}")
+        if record.expires_at:
+            print(f"Expires at: {record.expires_at}")
+        if record.client_id:
+            print(f"Stored GitHub client id: {record.client_id}")
+    history = HistoryStore().load()
+    print("Recent history:")
+    for item in history[-args.limit :]:
+        print(f"- {item.summary()}")
+
+
+def cmd_schedule(args: argparse.Namespace) -> None:
+    store = _load_store(args.passphrase)
+    record = store.load()
+    if record is None:
+        print("Credentials missing. Run authorize first.", file=sys.stderr)
+        sys.exit(1)
+    client_id = get_client_id() or record.client_id
+    if not client_id:
+        print(
+            "GitHub client id unavailable. Set ANYROUTER_CLIENT_ID or re-run authorize with --client-id.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    flow = AuthorizationFlow(OAuthConfig(client_id=client_id), store)
+
+    def job() -> None:
+        record = _ensure_credentials(store, flow)
+        client = SignInClient()
+        result = client.perform_sign_in(record)
+        HistoryStore().append(result)
+        LOGGER.info("%s", SignInClient.format_result(result))
+
+    scheduler = DailyScheduler(job)
+    scheduler.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Stopping scheduler...")
+        scheduler.stop()
+
+
+def cmd_clear(args: argparse.Namespace) -> None:
+    store = CredentialStore()
+    store.clear()
+    print("Stored credentials removed.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    command = args.command
+    if command == "authorize":
+        cmd_authorize(args)
+    elif command == "signin":
+        cmd_signin(args)
+    elif command == "status":
+        cmd_status(args)
+    elif command == "schedule":
+        cmd_schedule(args)
+    elif command == "clear":
+        cmd_clear(args)
+    else:  # pragma: no cover - argparse enforces choices
+        parser.error(f"Unknown command {command}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/anyrouter_auto/auth.py
+++ b/anyrouter_auto/auth.py
@@ -1,0 +1,155 @@
+"""OAuth helpers for the AnyRouter automation CLI."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, Optional
+
+from .config import OAuthConfig
+from .credentials import CredentialRecord, CredentialStore
+
+AUTHORIZATION_ENDPOINT = "https://anyrouter.top/api/oauth/authorize"
+TOKEN_ENDPOINT = "https://anyrouter.top/api/oauth/token"
+
+
+@dataclass(slots=True)
+class AuthorizationResult:
+    code: str
+    state: str
+    received_at: float
+
+
+class CallbackHandler(BaseHTTPRequestHandler):
+    """HTTP handler capturing OAuth redirect parameters."""
+
+    result: Optional[AuthorizationResult] = None
+    expected_state: Optional[str] = None
+    event: Optional[threading.Event] = None
+
+    def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != "/callback":
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown path")
+            return
+        params = urllib.parse.parse_qs(parsed.query)
+        code = params.get("code", [None])[0]
+        state = params.get("state", [None])[0]
+        if not code or not state:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Missing query parameters")
+            return
+        if self.expected_state and state != self.expected_state:
+            self.send_error(HTTPStatus.UNAUTHORIZED, "State mismatch")
+            return
+        self.result = AuthorizationResult(code=code, state=state, received_at=time.time())
+        if self.event:
+            self.event.set()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(b"<html><body>Authorization complete. You may close this window.</body></html>")
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003 - matching signature
+        return
+
+
+class AuthorizationFlow:
+    """Drive OAuth authorization with minimal dependencies."""
+
+    def __init__(self, config: OAuthConfig, store: CredentialStore) -> None:
+        self._config = config
+        self._store = store
+
+    # ------------------------------------------------------------------
+    def generate_state(self) -> str:
+        return secrets.token_urlsafe(16)
+
+    # ------------------------------------------------------------------
+    def build_authorization_url(self, state: str) -> str:
+        params = {
+            "client_id": self._config.client_id,
+            "redirect_uri": self._config.redirect_uri,
+            "response_type": "code",
+            "scope": self._config.scope,
+            "state": state,
+        }
+        query = urllib.parse.urlencode(params)
+        return f"{AUTHORIZATION_ENDPOINT}?{query}"
+
+    # ------------------------------------------------------------------
+    def wait_for_callback(self, state: str, timeout: float = 300.0) -> AuthorizationResult:
+        event = threading.Event()
+        CallbackHandler.expected_state = state
+        CallbackHandler.event = event
+        server = HTTPServer((self._config.redirect_host, self._config.redirect_port), CallbackHandler)
+        thread = threading.Thread(target=server.handle_request, daemon=True)
+        thread.start()
+        finished = event.wait(timeout)
+        server.server_close()
+        if not finished or CallbackHandler.result is None:
+            raise TimeoutError("Authorization callback not received")
+        result = CallbackHandler.result
+        CallbackHandler.result = None
+        return result
+
+    # ------------------------------------------------------------------
+    def exchange_code(self, result: AuthorizationResult) -> CredentialRecord:
+        payload = urllib.parse.urlencode(
+            {
+                "client_id": self._config.client_id,
+                "redirect_uri": self._config.redirect_uri,
+                "grant_type": "authorization_code",
+                "code": result.code,
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(TOKEN_ENDPOINT, data=payload, method="POST")
+        request.add_header("Content-Type", "application/x-www-form-urlencoded")
+        with urllib.request.urlopen(request, timeout=30) as response:  # nosec: B310 - target controlled by user
+            content = response.read()
+        data: Dict[str, str] = json.loads(content.decode("utf-8"))
+        expires_in = data.get("expires_in")
+        expires_at = time.time() + float(expires_in) if expires_in else None
+        record = CredentialRecord(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_at=expires_at,
+            scope=data.get("scope"),
+            client_id=self._config.client_id,
+        )
+        self._store.save(record)
+        return record
+
+    # ------------------------------------------------------------------
+    def refresh(self, record: CredentialRecord) -> CredentialRecord:
+        if not record.refresh_token:
+            raise RuntimeError("Refresh token missing; re-run authorization")
+        payload = urllib.parse.urlencode(
+            {
+                "client_id": self._config.client_id,
+                "redirect_uri": self._config.redirect_uri,
+                "grant_type": "refresh_token",
+                "refresh_token": record.refresh_token,
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(TOKEN_ENDPOINT, data=payload, method="POST")
+        request.add_header("Content-Type", "application/x-www-form-urlencoded")
+        with urllib.request.urlopen(request, timeout=30) as response:  # nosec: B310
+            content = response.read()
+        data: Dict[str, str] = json.loads(content.decode("utf-8"))
+        expires_in = data.get("expires_in")
+        record.access_token = data["access_token"]
+        record.refresh_token = data.get("refresh_token", record.refresh_token)
+        record.expires_at = time.time() + float(expires_in) if expires_in else None
+        record.scope = data.get("scope", record.scope)
+        self._store.save(record)
+        return record
+
+
+__all__ = ["AuthorizationFlow", "AuthorizationResult"]

--- a/anyrouter_auto/config.py
+++ b/anyrouter_auto/config.py
@@ -1,0 +1,64 @@
+"""Configuration helpers for AnyRouter automation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_CALLBACK_PORT = 8765
+DEFAULT_CALLBACK_HOST = "127.0.0.1"
+DEFAULT_SCHEDULE_HOUR = 9
+
+
+@dataclass(slots=True)
+class AppPaths:
+    """Resolve application directories lazily."""
+
+    base_dir: Path = Path.home() / ".anyrouter_auto"
+
+    def ensure(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def credentials_file(self) -> Path:
+        self.ensure()
+        return self.base_dir / "credentials.json"
+
+    @property
+    def schedule_file(self) -> Path:
+        self.ensure()
+        return self.base_dir / "schedule.json"
+
+
+@dataclass(slots=True)
+class OAuthConfig:
+    """High-level OAuth settings for anyrouter.top GitHub login."""
+
+    client_id: str
+    redirect_host: str = DEFAULT_CALLBACK_HOST
+    redirect_port: int = DEFAULT_CALLBACK_PORT
+    scope: str = "read:user"
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://{self.redirect_host}:{self.redirect_port}/callback"
+
+
+@dataclass(slots=True)
+class ScheduleConfig:
+    hour: int = DEFAULT_SCHEDULE_HOUR
+    minute: int = 0
+
+    @classmethod
+    def from_env(cls) -> "ScheduleConfig":
+        hour = int(os.environ.get("ANYROUTER_SCHEDULE_HOUR", DEFAULT_SCHEDULE_HOUR))
+        minute = int(os.environ.get("ANYROUTER_SCHEDULE_MINUTE", 0))
+        return cls(hour=hour, minute=minute)
+
+
+def get_client_id() -> Optional[str]:
+    """Return GitHub OAuth client id from environment or config file."""
+
+    return os.environ.get("ANYROUTER_CLIENT_ID")

--- a/anyrouter_auto/credentials.py
+++ b/anyrouter_auto/credentials.py
@@ -1,0 +1,113 @@
+"""Credential storage with lightweight XOR-based protection."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Optional
+
+from .config import AppPaths
+
+
+@dataclass(slots=True)
+class CredentialRecord:
+    """Persisted tokens required to call AnyRouter endpoints."""
+
+    access_token: str
+    refresh_token: Optional[str] = None
+    expires_at: Optional[float] = None
+    scope: Optional[str] = None
+    client_id: Optional[str] = None
+
+    @property
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return time.time() >= self.expires_at
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        return {k: v for k, v in payload.items() if v is not None}
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "CredentialRecord":
+        return cls(
+            access_token=payload["access_token"],
+            refresh_token=payload.get("refresh_token"),
+            expires_at=payload.get("expires_at"),
+            scope=payload.get("scope"),
+            client_id=payload.get("client_id"),
+        )
+
+
+class CredentialStore:
+    """Store credentials on disk with optional passphrase obfuscation.
+
+    The implementation intentionally avoids heavyweight dependencies. When the
+    ``passphrase`` argument is provided the JSON payload is XOR-masked with a key
+    derived from the passphrase. The mechanism is not intended to compete with
+    industry-grade encryption but merely to prevent accidental disclosure of the
+    token contents. Users should place stronger secrets into their OS keychain if
+    required.
+    """
+
+    def __init__(self, paths: Optional[AppPaths] = None, passphrase: str | None = None) -> None:
+        self._paths = paths or AppPaths()
+        self._passphrase = passphrase or ""
+
+    # ------------------------------------------------------------------
+    def load(self) -> Optional[CredentialRecord]:
+        path = self._paths.credentials_file
+        if not path.exists():
+            return None
+        data = path.read_bytes()
+        payload = self._decode(data)
+        try:
+            raw = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        return CredentialRecord.from_payload(raw)
+
+    # ------------------------------------------------------------------
+    def save(self, record: CredentialRecord) -> None:
+        path = self._paths.credentials_file
+        payload = json.dumps(record.to_payload(), indent=2, sort_keys=True)
+        path.write_bytes(self._encode(payload))
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        path = self._paths.credentials_file
+        if path.exists():
+            path.unlink()
+
+    # ------------------------------------------------------------------
+    def _encode(self, text: str) -> bytes:
+        buffer = text.encode("utf-8")
+        if not self._passphrase:
+            return buffer
+        key = _derive_key(self._passphrase, len(buffer))
+        return bytes(b ^ k for b, k in zip(buffer, key))
+
+    # ------------------------------------------------------------------
+    def _decode(self, data: bytes) -> str:
+        if not self._passphrase:
+            return data.decode("utf-8")
+        key = _derive_key(self._passphrase, len(data))
+        buffer = bytes(b ^ k for b, k in zip(data, key))
+        return buffer.decode("utf-8")
+
+
+def _derive_key(passphrase: str, size: int) -> bytes:
+    # Simple derivation using repeated SHA256 digests.
+    import hashlib
+
+    digest = hashlib.sha256(passphrase.encode("utf-8")).digest()
+    key = bytearray()
+    while len(key) < size:
+        key.extend(digest)
+        digest = hashlib.sha256(digest).digest()
+    return bytes(key[:size])
+
+
+__all__ = ["CredentialRecord", "CredentialStore"]

--- a/anyrouter_auto/history.py
+++ b/anyrouter_auto/history.py
@@ -1,0 +1,80 @@
+"""Historical logging helpers for sign-in runs."""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from .config import AppPaths
+from .signin import SignInResult
+
+
+@dataclass(slots=True)
+class HistoryRecord:
+    timestamp: float
+    status: str
+    reward: str
+    message: str
+
+    def summary(self) -> str:
+        when = dt.datetime.fromtimestamp(self.timestamp).isoformat()
+        reward = f" reward={self.reward}" if self.reward else ""
+        return f"[{when}] {self.status.upper()} {self.message}{reward}".strip()
+
+
+class HistoryStore:
+    """Persist sign-in outcomes in CSV format."""
+
+    def __init__(self, paths: AppPaths | None = None) -> None:
+        self._paths = paths or AppPaths()
+
+    @property
+    def csv_path(self) -> Path:
+        self._paths.ensure()
+        return self._paths.base_dir / "history.csv"
+
+    def append(self, result: SignInResult) -> None:
+        record = HistoryRecord(
+            timestamp=result.timestamp,
+            status="success" if result.success else "failure",
+            reward=result.reward or "",
+            message=result.message,
+        )
+        path = self.csv_path
+        is_new = not path.exists()
+        with path.open("a", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            if is_new:
+                writer.writerow(["timestamp", "status", "reward", "message"])
+            writer.writerow([record.timestamp, record.status, record.reward, record.message])
+
+    def load(self) -> List[HistoryRecord]:
+        path = self.csv_path
+        if not path.exists():
+            return []
+        with path.open("r", newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            items: List[HistoryRecord] = []
+            for row in reader:
+                items.append(
+                    HistoryRecord(
+                        timestamp=float(row["timestamp"]),
+                        status=row["status"],
+                        reward=row.get("reward", ""),
+                        message=row.get("message", ""),
+                    )
+                )
+        return items
+
+    def format(self, records: Iterable[HistoryRecord]) -> str:
+        lines = ["timestamp,status,reward,message"]
+        for item in records:
+            when = dt.datetime.fromtimestamp(item.timestamp).isoformat()
+            lines.append(f"{when},{item.status},{item.reward},{item.message}")
+        return "\n".join(lines)
+
+
+__all__ = ["HistoryStore", "HistoryRecord"]

--- a/anyrouter_auto/scheduler.py
+++ b/anyrouter_auto/scheduler.py
@@ -1,0 +1,99 @@
+"""Simple daily scheduler for sign-in job."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from .config import AppPaths, ScheduleConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ScheduleState:
+    hour: int
+    minute: int
+    last_run: Optional[float] = None
+
+    def to_payload(self) -> dict[str, int | float | None]:
+        return {"hour": self.hour, "minute": self.minute, "last_run": self.last_run}
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, int | float | None]) -> "ScheduleState":
+        return cls(hour=int(payload["hour"]), minute=int(payload["minute"]), last_run=payload.get("last_run"))
+
+
+class DailyScheduler:
+    """Run a callable at a fixed daily time."""
+
+    def __init__(self, callback: Callable[[], None], config: Optional[ScheduleConfig] = None, paths: Optional[AppPaths] = None) -> None:
+        self._callback = callback
+        self._config = config or ScheduleConfig.from_env()
+        self._paths = paths or AppPaths()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # ------------------------------------------------------------------
+    def _state_file(self) -> Path:
+        return self._paths.schedule_file
+
+    # ------------------------------------------------------------------
+    def load_state(self) -> ScheduleState:
+        path = self._state_file()
+        if not path.exists():
+            return ScheduleState(hour=self._config.hour, minute=self._config.minute)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            return ScheduleState.from_payload(payload)
+        except Exception:  # pragma: no cover - defensive parsing
+            return ScheduleState(hour=self._config.hour, minute=self._config.minute)
+
+    # ------------------------------------------------------------------
+    def save_state(self, state: ScheduleState) -> None:
+        payload = json.dumps(state.to_payload(), indent=2)
+        self._state_file().write_text(payload, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1)
+
+    # ------------------------------------------------------------------
+    def _run_loop(self) -> None:
+        state = self.load_state()
+        LOGGER.info("Scheduler started for %02d:%02d", state.hour, state.minute)
+        while not self._stop_event.is_set():
+            now = dt.datetime.now()
+            target = now.replace(hour=state.hour, minute=state.minute, second=0, microsecond=0)
+            if target <= now:
+                target = target + dt.timedelta(days=1)
+            wait_seconds = (target - now).total_seconds()
+            LOGGER.debug("Next run at %s (%.0f seconds)", target.isoformat(), wait_seconds)
+            finished = self._stop_event.wait(wait_seconds)
+            if finished:
+                break
+            try:
+                self._callback()
+                state.last_run = time.time()
+                self.save_state(state)
+            except Exception as exc:  # pragma: no cover - runtime safety
+                LOGGER.exception("Scheduled job failed: %s", exc)
+
+
+__all__ = ["DailyScheduler", "ScheduleState"]

--- a/anyrouter_auto/signin.py
+++ b/anyrouter_auto/signin.py
@@ -1,0 +1,84 @@
+"""Client for AnyRouter sign-in endpoint."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .credentials import CredentialRecord
+
+SIGNIN_ENDPOINT = "https://anyrouter.top/api/checkin"
+CSRF_ENDPOINT = "https://anyrouter.top/api/session"
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SignInResult:
+    success: bool
+    message: str
+    reward: Optional[str]
+    timestamp: float
+
+
+class SignInClient:
+    """Perform authenticated requests against AnyRouter."""
+
+    def __init__(self, user_agent: str | None = None) -> None:
+        self._user_agent = user_agent or "anyrouter-auto/0.1"
+
+    # ------------------------------------------------------------------
+    def _build_request(self, url: str, token: str, method: str = "GET", data: Optional[Dict[str, str]] = None) -> urllib.request.Request:
+        encoded = None
+        if data:
+            encoded = json.dumps(data).encode("utf-8")
+        request = urllib.request.Request(url, data=encoded, method=method)
+        request.add_header("Authorization", f"Bearer {token}")
+        request.add_header("User-Agent", self._user_agent)
+        if data:
+            request.add_header("Content-Type", "application/json")
+        return request
+
+    # ------------------------------------------------------------------
+    def fetch_csrf_token(self, record: CredentialRecord) -> Optional[str]:
+        request = self._build_request(CSRF_ENDPOINT, record.access_token)
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:  # nosec: B310
+                payload = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:  # pragma: no cover - network heavy
+            LOGGER.warning("Failed to refresh session metadata: %s", exc)
+            return None
+        return payload.get("csrf_token")
+
+    # ------------------------------------------------------------------
+    def perform_sign_in(self, record: CredentialRecord) -> SignInResult:
+        body = {"timestamp": int(time.time())}
+        request = self._build_request(SIGNIN_ENDPOINT, record.access_token, method="POST", data=body)
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:  # nosec: B310
+                payload = json.loads(response.read().decode("utf-8"))
+        except Exception as exc:  # pragma: no cover - network heavy
+            LOGGER.error("Sign-in request failed: %s", exc)
+            raise
+        reward = payload.get("reward")
+        message = payload.get("message", "")
+        success = bool(payload.get("success", False))
+        timestamp = payload.get("timestamp")
+        if timestamp is None:
+            timestamp = time.time()
+        return SignInResult(success=success, message=message, reward=reward, timestamp=float(timestamp))
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def format_result(result: SignInResult) -> str:
+        status = "SUCCESS" if result.success else "FAILED"
+        when = dt.datetime.fromtimestamp(result.timestamp).isoformat()
+        reward = result.reward or ""
+        return f"[{when}] {status} {result.message} {reward}".strip()
+
+
+__all__ = ["SignInClient", "SignInResult"]

--- a/anyrouter_auto/version.py
+++ b/anyrouter_auto/version.py
@@ -1,0 +1,3 @@
+"""Package version (managed manually)."""
+
+VERSION = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "anyrouter-auto"
+version = "0.1.0"
+description = "Minimal-dependency automation toolkit for anyrouter.top daily sign-in"
+authors = [{name = "Automation Bot"}]
+requires-python = ">=3.11"
+dependencies = []
+readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.scripts]
+anyrouter-auto = "anyrouter_auto.__main__:main"
+anyrouter_auto = "anyrouter_auto.__main__:main"


### PR DESCRIPTION
## Summary
- remove the Playwright browser launcher and rely on the system browser to open the authorization link
- delete the Playwright dependency from the packaging metadata and simplify the README instructions accordingly
- prompt for the GitHub client id when it is not provided, persist it with the saved credentials, and reuse the stored value across commands

## Testing
- python -m compileall anyrouter_auto

------
https://chatgpt.com/codex/tasks/task_e_68d1fc1cba608321b8fde283db64a551